### PR TITLE
feat: option to ignore tracing for path

### DIFF
--- a/config/stackdriver.php
+++ b/config/stackdriver.php
@@ -88,6 +88,8 @@ return [
                 'workerNum' => 1,
             ],
         ],
+
+        'blacklist' => [],
     ],
 
     'error_reporting' => [

--- a/config/stackdriver.php
+++ b/config/stackdriver.php
@@ -89,7 +89,7 @@ return [
             ],
         ],
 
-        'blacklist' => [],
+        'ignored_paths' => [],
     ],
 
     'error_reporting' => [

--- a/src/Stackdriver.php
+++ b/src/Stackdriver.php
@@ -4,7 +4,6 @@ namespace GlueDev\Laravel\Stackdriver;
 
 use Google\Cloud\Logging\LoggingClient;
 use Google\Cloud\Logging\PsrLogger;
-use Illuminate\Support\Str;
 use OpenCensus\Trace\Exporter\StackdriverExporter;
 use OpenCensus\Trace\Tracer;
 use OpenCensus\Trace\Integrations\Laravel;
@@ -62,7 +61,8 @@ class Stackdriver
             return;
         }
 
-        if (Str::startsWith(request()->getPathInfo(), config('stackdriver.tracing.blacklist'))) {
+        $ignoredPaths = config('stackdriver.tracing.ignored_paths', []);
+        if ($this->app['request']->is($ignoredPaths)) {
             return;
         }
 

--- a/src/Stackdriver.php
+++ b/src/Stackdriver.php
@@ -4,6 +4,7 @@ namespace GlueDev\Laravel\Stackdriver;
 
 use Google\Cloud\Logging\LoggingClient;
 use Google\Cloud\Logging\PsrLogger;
+use Illuminate\Support\Str;
 use OpenCensus\Trace\Exporter\StackdriverExporter;
 use OpenCensus\Trace\Tracer;
 use OpenCensus\Trace\Integrations\Laravel;
@@ -58,6 +59,10 @@ class Stackdriver
 
         // Do not run in CLI mode
         if (php_sapi_name() == 'cli') {
+            return;
+        }
+
+        if (Str::startsWith(request()->getPathInfo(), config('stackdriver.tracing.blacklist'))) {
             return;
         }
 


### PR DESCRIPTION
This will prevent blacklisted paths to being traced. To prevent trace of Laravel Nova requests for example, just add the `/nova-api` to the blacklist array in the config file.

Closes #7 